### PR TITLE
Finalize Code of Conduct

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -22,7 +22,7 @@ Individuals who participate (or plan to participate) in Orchestructure events sh
 
 #### Consequences of Unacceptable Behavior
 
-If a participant engages in harassing behavior, the event organizers may take any action they deem appropriate depending on the circumstances, ranging from issuance of a warning to the offending individual to expulsion from the conference with no refund. Orchestructure organizers reserve the right to exclude any participant found to be engaging in harassing behavior from participating in any further Orchestructure events, trainings or other activities.
+If a participant engages in harassing behavior, the event organizers may take any action they deem appropriate depending on the circumstances, ranging from issuance of a warning to the offending individual to expulsion from the event, and if charged with no refund. Orchestructure organizers reserve the right to exclude any participant found to be engaging in harassing behavior from participating in any further Orchestructure events, trainings or other activities.
 
 If a participant (or individual wishing to participate in a Orchestructure event), through postings on social media or other online publications or another form of electronic communication, engages in conduct that violates this policy, whether before, during or after a Orchestructure event, the Orchestructure organizers may take appropriate corrective action, which could include imposing a temporary or permanent ban on an individual’s participation in future Orchestructure events.
 

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,6 +1,6 @@
 ## Orchestructure Code of Conduct
 
-The following applies to all Orchestructure related resources, events, and other public opportunities in which Orchestructure provides. This includes but is not limited to our [Github presence](https://github.com/orchestructure), [meetup hosting](https://www.meetup.com/orchestructure/), and any other projects, events, efforts, competitions, etc., in-person or digital.
+The following applies to all Orchestructure related resources, events, and other public opportunities in which Orchestructure operates in any capacity. This includes but is not limited to our [Github presence](https://github.com/orchestructure), [meetup hosting](https://www.meetup.com/orchestructure/), [Slack channel](https://madeina2.slack.com/messages/C45JHC0A0/), and any other projects, events, efforts, etc., in-person or digital.
 
 ### Events Code of Conduct
 

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -32,7 +32,7 @@ If you are being harassed, notice that someone else is being harassed, or have a
 
 #### Incident Response
 
-Our staff/organizers will respond to all harassment reports with utmost urgency. As referenced above, if a participant engages in harassing behavior, the event organizers may take any action they deem appropriate, ranging from issuance of a warning to the offending individual to expulsion from the event (with no refund). Orchestructure reserves the right to exclude any participant found to be engaging in harassing behavior from participating in any further Orchestructure events, trainings or other activities.
+Our staff/organizers will respond to all harassment reports with utmost urgency. As referenced above, if a participant engages in harassing behavior, the event organizers may take any action they deem appropriate, ranging from issuance of a warning to the offending individual to expulsion from the event, if charged with no refund. Orchestructure reserves the right to exclude any participant found to be engaging in harassing behavior from participating in any further Orchestructure events, trainings or other activities.
 
 Event staff will also provide support to victims, including, but not limited to: Providing an Escort, Contacting Venue security or local law encforcement, and briefing key event staff for response/victim assistance. In addition, staff will assist those experiencing harassment to ensure they feel safe for the duration of the event.
 

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,0 +1,41 @@
+## Orchestructure Code of Conduct
+
+As contributors and maintainers of this project, and in the interest of fostering
+an open and welcoming community, we pledge to respect all people who contribute
+through reporting issues, posting feature requests, updating documentation,
+submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free experience for
+everyone, regardless of level of experience, gender, gender identity and expression,
+sexual orientation, disability, personal appearance, body size, race, ethnicity, age,
+religion, or nationality.
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery
+* Personal attacks
+* Trolling or insulting/derogatory comments
+* Public or private harassment
+* Publishing other's private information, such as physical or electronic addresses,
+ without explicit permission
+* Other unethical or unprofessional conduct. If you wouldn't do it at work, don't do it here.
+
+Project maintainers have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are not
+aligned to this Code of Conduct. By adopting this Code of Conduct, project maintainers
+commit themselves to fairly and consistently applying these principles to every aspect
+of managing this project. Project maintainers who do not follow or enforce the Code of
+Conduct may be permanently removed from the project team.
+
+This code of conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting a CNCF project maintainer, Sarah Novotny <sarahnovotny@google.com>, and/or Dan Kohn <dan@linuxfoundation.org>.
+
+This Code of Conduct is adapted from the Contributor Covenant
+(http://contributor-covenant.org), version 1.2.0, available at
+http://contributor-covenant.org/version/1/2/0/
+
+### CNCF Events Code of Conduct
+
+CNCF events are governed by the Linux Foundation [Code of Conduct](http://events.linuxfoundation.org/events/cloudnativecon/attend/code-of-conduct) available on the event page. This is designed to be compatible with the above policy and also includes more details on responding to incidents.

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -72,7 +72,7 @@ Conduct may be permanently removed from the project team.
 This code of conduct applies both within project spaces and in public spaces
 when an individual is representing the project or its community.
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the Orchestructure project maintainers at <orchestructure.meetup@gmail.com>.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the Orchestructure project maintainers at orchestructure.meetup (at) gmail (dot) com..
 
 This Code of Conduct is adapted from the Contributor Covenant
 (http://contributor-covenant.org), version 1.2.0, available at

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,5 +1,47 @@
 ## Orchestructure Code of Conduct
 
+The following applies to all Orchestructure related resources, events, and other public opportunities in which Orchestructure provides. This includes but is not limited to our [Github presence](https://github.com/orchestructure), [meetup hosting](https://www.meetup.com/orchestructure/), and any other projects, events, efforts, competitions, etc., in-person or digital.
+
+### Events Code of Conduct
+
+Orchestructure and its project communities are dedicated to providing a harassment-free experience for participants at all of our events. Orchestructure events are working meetups intended for professional networking and collaboration within the open source, DevOps, and local communities. They exist to encourage the open exchange of ideas and expression and require an environment that recognizes the inherent worth of every person and group. While at Orchestructure events or related ancillary or social events, any participants, including members, speakers, attendees, volunteers, sponsors, exhibitors, booth staff and anyone else, should not engage in harassment in any form.
+
+This Code of Conduct may be revised at any time by the Orchestructure board and the terms are non-negotiable. Your attendance at any Orchestructure event indicates your agreement to abide by this policy and its terms.
+
+#### Expected Behavior
+
+All event participants are expected to behave in accordance with professional standards, with both this Code of Conduct as well as their respective employer’s policies governing appropriate workplace behavior and applicable laws.
+
+#### Unacceptable Behavior
+
+Harassment will not be tolerated in any form, including, but not limited to, harassment based on gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, age, religion or any other status protected by laws in which the conference or program is being held. Harassment includes the use of abusive, offensive or degrading language, intimidation, stalking, harassing photography or recording, inappropriate physical contact, sexual imagery and unwelcome sexual advances or requests for sexual favors. Any report of harassment at one of our events will be addressed immediately. Participants asked to stop any harassing behavior are expected to comply immediately. Anyone who witnesses or is subjected to unacceptable behavior should notify a meetup/event organizer at once.
+
+Exhibitors should not use sexualized images, activities, or other material in their booths/areas and must refrain from the use of sexualized clothing, uniforms, costumes, or otherwise creating a sexualized environment. Speakers should not use sexual language, images, or any language or images that would constitute harassment as defined above in their talks.
+
+Individuals who participate (or plan to participate) in Orchestructure events should conduct themselves at all times in a manner that comports with both the letter and spirit of this policy prohibiting harassment and abusive behavior, whether before, during or after the event. This includes statements made in social media postings, online publications, text messages, and all other forms of electronic communication.
+
+#### Consequences of Unacceptable Behavior
+
+If a participant engages in harassing behavior, the event organizers may take any action they deem appropriate depending on the circumstances, ranging from issuance of a warning to the offending individual to expulsion from the conference with no refund. Orchestructure organizers reserve the right to exclude any participant found to be engaging in harassing behavior from participating in any further Orchestructure events, trainings or other activities.
+
+If a participant (or individual wishing to participate in a Orchestructure event), through postings on social media or other online publications or another form of electronic communication, engages in conduct that violates this policy, whether before, during or after a Orchestructure event, the Orchestructure organizers may take appropriate corrective action, which could include imposing a temporary or permanent ban on an individual’s participation in future Orchestructure events.
+
+#### What to do if you Witness or are Subject to Unacceptable Behavior
+
+If you are being harassed, notice that someone else is being harassed, or have any other concerns relating to harassment, please contact a member of event staff immediately. Event staff introduce themselves at the beginning of every event, can be identified by t-shirts/staff badges, and are always available at every Orchestructure event. You are also encouraged to contact the Orchestructure organizers at orchestructure.meetup (at) gmail (dot) com.
+
+#### Incident Response
+
+Our staff/organizers will respond to all harassment reports with utmost urgency. As referenced above, if a participant engages in harassing behavior, the event organizers may take any action they deem appropriate, ranging from issuance of a warning to the offending individual to expulsion from the event (with no refund). Orchestructure reserves the right to exclude any participant found to be engaging in harassing behavior from participating in any further Orchestructure events, trainings or other activities.
+
+Event staff will also provide support to victims, including, but not limited to: Providing an Escort, Contacting Venue security or local law encforcement, and briefing key event staff for response/victim assistance. In addition, staff will assist those experiencing harassment to ensure they feel safe for the duration of the event.
+
+#### Pre-Event Concerns
+
+If you are planning to attend an upcoming event and have concerns regarding another individual who may be present, please contact the Orchestructure organizers at orchestructure.meetup (at) gmail (dot) com. Precautions will be taken to ensure your comfort and safety, including, but not limited to: providing an escort, prepping onsite event staff, keeping victim and harasser from attending the same talks/social events and providing onsite contact cell phone numbers for immediate contact.
+
+### Projects Code of Conduct
+
 As contributors and maintainers of this project, and in the interest of fostering
 an open and welcoming community, we pledge to respect all people who contribute
 through reporting issues, posting feature requests, updating documentation,
@@ -30,12 +72,8 @@ Conduct may be permanently removed from the project team.
 This code of conduct applies both within project spaces and in public spaces
 when an individual is representing the project or its community.
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting a CNCF project maintainer, Sarah Novotny <sarahnovotny@google.com>, and/or Dan Kohn <dan@linuxfoundation.org>.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the Orchestructure project maintainers at <orchestructure.meetup@gmail.com>.
 
 This Code of Conduct is adapted from the Contributor Covenant
 (http://contributor-covenant.org), version 1.2.0, available at
 http://contributor-covenant.org/version/1/2/0/
-
-### CNCF Events Code of Conduct
-
-CNCF events are governed by the Linux Foundation [Code of Conduct](http://events.linuxfoundation.org/events/cloudnativecon/attend/code-of-conduct) available on the event page. This is designed to be compatible with the above policy and also includes more details on responding to incidents.

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -28,7 +28,7 @@ If a participant (or individual wishing to participate in a Orchestructure event
 
 #### What to do if you Witness or are Subject to Unacceptable Behavior
 
-If you are being harassed, notice that someone else is being harassed, or have any other concerns relating to harassment, please contact a member of event staff immediately. Event staff introduce themselves at the beginning of every event, can be identified by t-shirts/staff badges, and are always available at every Orchestructure event. You are also encouraged to contact the Orchestructure organizers at orchestructure.meetup (at) gmail (dot) com.
+If you are being harassed, notice that someone else is being harassed, or have any other concerns relating to harassment, please contact a member of [Orchestructure Organizers](https://www.meetup.com/orchestructure/members/?op=leaders). The Organizers will introduce themselves at the beginning of every event, with at least one on-site at all times for its duration. The Orchestructure Organizers may also be contacted via email at orchestructure.meetup (at) gmail (dot) com.
 
 #### Incident Response
 


### PR DESCRIPTION
Mostly taken from the excellent CNCF and Linux Foundation pages, with some minor changes to reflect our type of events and opportunities, as well as appropriate contact information.

This will need to be linked to from each repo, our meetup page, and Slack.